### PR TITLE
Fix use-after-free in ssh_kex2

### DIFF
--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -221,7 +221,6 @@ ssh_kex2(struct ssh *ssh, char *host, struct sockaddr *hostaddr, u_short port)
 			orig = myproposal[PROPOSAL_SERVER_HOST_KEY_ALGS];
 			xasprintf(&myproposal[PROPOSAL_SERVER_HOST_KEY_ALGS],
 			    "%s,null", orig);
-			free(gss);
 		}
 	}
 #endif


### PR DESCRIPTION
gss is used (and indeed freed) further down in this function, and
mustn't be freed here.