### PR TITLE
Simplify GSSAPI key exchange algorithm handling

### DIFF
--- a/kex.c
+++ b/kex.c
@@ -116,6 +116,9 @@ static const struct kexalg kexalgs[] = {
 	{ KEX_SNTRUP4591761X25519_SHA512, KEX_KEM_SNTRUP4591761X25519_SHA512, 0,
 	    SSH_DIGEST_SHA512 },
 #endif /* HAVE_EVP_SHA256 || !WITH_OPENSSL */
+	{ NULL, -1, -1, -1},
+};
+static const struct kexalg kexalg_prefixes[] = {
 #ifdef GSSAPI
 	{ KEX_GSS_GEX_SHA1_ID, KEX_GSS_GEX_SHA1, 0, SSH_DIGEST_SHA1 },
 	{ KEX_GSS_GRP1_SHA1_ID, KEX_GSS_GRP1_SHA1, 0, SSH_DIGEST_SHA1 },
@@ -159,12 +162,10 @@ kex_alg_by_name(const char *name)
 	for (k = kexalgs; k->name != NULL; k++) {
 		if (strcmp(k->name, name) == 0)
 			return k;
-#ifdef GSSAPI
-		if (strncmp(name, "gss-", 4) == 0) {
-			if (strncmp(k->name, name, strlen(k->name)) == 0)
-				return k;
-		}
-#endif
+	}
+	for (k = kexalg_prefixes; k->name != NULL; k++) {
+		if (strncmp(k->name, name, strlen(k->name)) == 0)
+			return k;
 	}
 	return NULL;
 }

--- a/regress/kextype.sh
+++ b/regress/kextype.sh
@@ -14,10 +14,6 @@ echo "KexAlgorithms=$KEXOPT" >> $OBJ/sshd_proxy
 
 tries="1 2 3 4"
 for k in `${SSH} -Q kex`; do
-	# ignore GSSAPI key exchange mechanisms (all of them start with gss-)
-	case $k in
-		gss-* ) continue ;;
-	esac
 	verbose "kex $k"
 	for i in $tries; do
 		${SSH} -F $OBJ/ssh_proxy -o KexAlgorithms=$k x true

--- a/regress/rekey.sh
+++ b/regress/rekey.sh
@@ -38,10 +38,6 @@ increase_datafile_size 300
 
 opts=""
 for i in `${SSH} -Q kex`; do
-	# ignore GSSAPI key exchange mechanisms (all of them start with gss-)
-	case $i in
-		gss-* ) continue ;;
-	esac
 	opts="$opts KexAlgorithms=$i"
 done
 for i in `${SSH} -Q cipher`; do
@@ -60,10 +56,6 @@ done
 if ${SSH} -Q cipher-auth | grep '^.*$' >/dev/null 2>&1 ; then
   for c in `${SSH} -Q cipher-auth`; do
     for kex in `${SSH} -Q kex`; do
-	# ignore GSSAPI key exchange mechanisms (all of them start with gss-)
-	case $kex in
-		gss-* ) continue ;;
-	esac
 	verbose "client rekey $c $kex"
 	ssh_data_rekeying "KexAlgorithms=$kex" -oRekeyLimit=256k -oCiphers=$c
     done


### PR DESCRIPTION
It doesn't make much sense to have "ssh -Q kex" output names which are
only prefixes and which thus can't be used in the KexAlgorithms option.
If this is needed then we should invent a new -Q option name for it
instead (perhaps "gssapi-kex"), but that can probably wait.

Keeping track of algorithm prefixes in a separate array also simplifies
kex_alg_by_name.