### PR TITLE
Unify get_buffer_desc in the gssapi kex code

### DIFF
--- a/gss-genr.c
+++ b/gss-genr.c
@@ -84,6 +84,21 @@ ssh_gssapi_get_buffer_desc(struct sshbuf *b, gss_buffer_desc *g)
 	return 0;
 }
 
+/* sshpkt_get of gss_buffer_desc */
+int
+ssh_gssapi_sshpkt_get_buffer_desc(struct ssh *ssh, gss_buffer_desc *g)
+{
+	int r;
+	u_char *p;
+	size_t len;
+
+	if ((r = sshpkt_get_string(ssh, &p, &len)) != 0)
+		return r;
+	g->value = p;
+	g->length = len;
+	return 0;
+}
+
 /*
  * Return a list of the gss-group1-sha1 mechanisms supported by this program
  *

--- a/kexgsss.c
+++ b/kexgsss.c
@@ -67,7 +67,6 @@ kexgss_server(struct ssh *ssh)
 	gss_buffer_desc gssbuf, recv_tok, msg_tok;
 	gss_buffer_desc send_tok = GSS_C_EMPTY_BUFFER;
 	Gssctxt *ctxt = NULL;
-	size_t slen;
 	struct sshbuf *shared_secret = NULL;
 	struct sshbuf *client_pubkey = NULL;
 	struct sshbuf *server_pubkey = NULL;
@@ -75,7 +74,6 @@ kexgss_server(struct ssh *ssh)
 	int type = 0;
 	gss_OID oid;
 	char *mechs;
-	u_char *value = NULL;
 	u_char hash[SSH_DIGEST_MAX_LENGTH];
 	size_t hashlen;
 	int r;
@@ -108,12 +106,11 @@ kexgss_server(struct ssh *ssh)
 		case SSH2_MSG_KEXGSS_INIT:
 			if (client_pubkey != NULL)
 				fatal("Received KEXGSS_INIT after initialising");
-			if ((r = sshpkt_get_string(ssh, &value, &slen)) != 0 ||
+			if ((r = ssh_gssapi_sshpkt_get_buffer_desc(ssh,
+			        &recv_tok)) != 0 ||
 			    (r = sshpkt_getb_froms(ssh, &client_pubkey)) != 0 ||
 			    (r = sshpkt_get_end(ssh)) != 0)
 				fatal("sshpkt failed: %s", ssh_err(r));
-			recv_tok.value = value;
-			recv_tok.length = slen;
 
 			switch (kex->kex_type) {
 			case KEX_GSS_GRP1_SHA1:
@@ -140,11 +137,10 @@ kexgss_server(struct ssh *ssh)
 			/* Send SSH_MSG_KEXGSS_HOSTKEY here, if we want */
 			break;
 		case SSH2_MSG_KEXGSS_CONTINUE:
-			if ((r = sshpkt_get_string(ssh, &value, &slen)) != 0 ||
+			if ((r = ssh_gssapi_sshpkt_get_buffer_desc(ssh,
+			        &recv_tok)) != 0 ||
 			    (r = sshpkt_get_end(ssh)) != 0)
 				fatal("sshpkt failed: %s", ssh_err(r));
-			recv_tok.value = value;
-			recv_tok.length = slen;
 			break;
 		default:
 			sshpkt_disconnect(ssh,
@@ -266,7 +262,6 @@ kexgssgex_server(struct ssh *ssh)
 	gss_buffer_desc gssbuf, recv_tok, msg_tok;
 	gss_buffer_desc send_tok = GSS_C_EMPTY_BUFFER;
 	Gssctxt *ctxt = NULL;
-	size_t slen;
 	struct sshbuf *shared_secret = NULL;
 	int type = 0;
 	gss_OID oid;
@@ -278,7 +273,6 @@ kexgssgex_server(struct ssh *ssh)
 	int min = -1, max = -1, nbits = -1;
 	int cmin = -1, cmax = -1; /* client proposal */
 	struct sshbuf *empty = sshbuf_new();
-	u_char *value = NULL;
 	int r;
 
 	/* Initialise GSSAPI */
@@ -347,21 +341,19 @@ kexgssgex_server(struct ssh *ssh)
 		case SSH2_MSG_KEXGSS_INIT:
 			if (dh_client_pub != NULL)
 				fatal("Received KEXGSS_INIT after initialising");
-			if ((r = sshpkt_get_string(ssh, &value, &slen)) != 0 ||
+			if ((r = ssh_gssapi_sshpkt_get_buffer_desc(ssh,
+			        &recv_tok)) != 0 ||
 			    (r = sshpkt_get_bignum2(ssh, &dh_client_pub)) != 0 ||
 			    (r = sshpkt_get_end(ssh)) != 0)
 				fatal("sshpkt failed: %s", ssh_err(r));
-			recv_tok.value = value;
-			recv_tok.length = slen;
 
 			/* Send SSH_MSG_KEXGSS_HOSTKEY here, if we want */
 			break;
 		case SSH2_MSG_KEXGSS_CONTINUE:
-			if ((r = sshpkt_get_string(ssh, &value, &slen)) != 0 ||
+			if ((r = ssh_gssapi_sshpkt_get_buffer_desc(ssh,
+			        &recv_tok)) != 0 ||
 			    (r = sshpkt_get_end(ssh)) != 0)
 				fatal("sshpkt failed: %s", ssh_err(r));
-			recv_tok.value = value;
-			recv_tok.length = slen;
 			break;
 		default:
 			sshpkt_disconnect(ssh,

--- a/ssh-gss.h
+++ b/ssh-gss.h
@@ -134,6 +134,7 @@ OM_uint32 ssh_gssapi_test_oid_supported(OM_uint32 *, gss_OID, int *);
 
 struct sshbuf;
 int ssh_gssapi_get_buffer_desc(struct sshbuf *, gss_buffer_desc *);
+int ssh_gssapi_sshpkt_get_buffer_desc(struct ssh *, gss_buffer_desc *);
 
 OM_uint32 ssh_gssapi_import_name(Gssctxt *, const char *);
 OM_uint32 ssh_gssapi_init_ctx(Gssctxt *, int,


### PR DESCRIPTION
Alternative solution for #6. Unfortunately, I could not reuse the `ssh_gssapi_get_buffer_desc()` function, because the `struct ssh` and `struct session_state` are opaque, but I think this improves readability.