### PR TITLE
ssh: Allow to query for the GSSAPI Kex algorithms from ssh

### DIFF
--- a/gss-genr.c
+++ b/gss-genr.c
@@ -42,8 +42,10 @@
 #include "log.h"
 #include "ssh2.h"
 #include "cipher.h"
+#include "sshkey.h"
 #include "kex.h"
 #include "digest.h"
+#include "packet.h"
 
 #include "ssh-gss.h"
 

--- a/kex.c
+++ b/kex.c
@@ -337,7 +337,7 @@ kex_assemble_names(char **listp, const char *def, const char *all)
 
 /* Validate GSS KEX method name list */
 int
-gss_kex_names_valid(const char *names)
+kex_gss_names_valid(const char *names)
 {
 	char *s, *cp, *p;
 

--- a/kex.c
+++ b/kex.c
@@ -118,7 +118,7 @@ static const struct kexalg kexalgs[] = {
 #endif /* HAVE_EVP_SHA256 || !WITH_OPENSSL */
 	{ NULL, -1, -1, -1},
 };
-static const struct kexalg kexalg_prefixes[] = {
+static const struct kexalg gss_kexalgs[] = {
 #ifdef GSSAPI
 	{ KEX_GSS_GEX_SHA1_ID, KEX_GSS_GEX_SHA1, 0, SSH_DIGEST_SHA1 },
 	{ KEX_GSS_GRP1_SHA1_ID, KEX_GSS_GRP1_SHA1, 0, SSH_DIGEST_SHA1 },
@@ -132,14 +132,14 @@ static const struct kexalg kexalg_prefixes[] = {
 	{ NULL, -1, -1, -1 },
 };
 
-char *
-kex_alg_list(char sep)
+static char *
+kex_alg_list_internal(char sep, const struct kexalg *algs)
 {
 	char *ret = NULL, *tmp;
 	size_t nlen, rlen = 0;
 	const struct kexalg *k;
 
-	for (k = kexalgs; k->name != NULL; k++) {
+	for (k = algs; k->name != NULL; k++) {
 		if (ret != NULL)
 			ret[rlen++] = sep;
 		nlen = strlen(k->name);
@@ -154,6 +154,18 @@ kex_alg_list(char sep)
 	return ret;
 }
 
+char *
+kex_alg_list(char sep)
+{
+	return kex_alg_list_internal(sep, kexalgs);
+}
+
+char *
+kex_gss_alg_list(char sep)
+{
+	return kex_alg_list_internal(sep, gss_kexalgs);
+}
+
 static const struct kexalg *
 kex_alg_by_name(const char *name)
 {
@@ -163,7 +175,7 @@ kex_alg_by_name(const char *name)
 		if (strcmp(k->name, name) == 0)
 			return k;
 	}
-	for (k = kexalg_prefixes; k->name != NULL; k++) {
+	for (k = gss_kexalgs; k->name != NULL; k++) {
 		if (strncmp(k->name, name, strlen(k->name)) == 0)
 			return k;
 	}

--- a/kex.h
+++ b/kex.h
@@ -193,7 +193,7 @@ char	*kex_alg_list(char);
 char	*kex_gss_alg_list(char);
 char	*kex_names_cat(const char *, const char *);
 int	 kex_assemble_names(char **, const char *, const char *);
-int	 gss_kex_names_valid(const char *);
+int	 kex_gss_names_valid(const char *);
 
 int	 kex_exchange_identification(struct ssh *, int, const char *);
 

--- a/kex.h
+++ b/kex.h
@@ -190,6 +190,7 @@ struct kex {
 
 int	 kex_names_valid(const char *);
 char	*kex_alg_list(char);
+char	*kex_gss_alg_list(char);
 char	*kex_names_cat(const char *, const char *);
 int	 kex_assemble_names(char **, const char *, const char *);
 int	 gss_kex_names_valid(const char *);

--- a/readconf.c
+++ b/readconf.c
@@ -1027,7 +1027,7 @@ parse_time:
 		if (!arg || *arg == '\0')
 			fatal("%.200s line %d: Missing argument.",
 			    filename, linenum);
-		if (!gss_kex_names_valid(arg))
+		if (!kex_gss_names_valid(arg))
 			fatal("%.200s line %d: Bad GSSAPI KexAlgorithms '%s'.",
 			    filename, linenum, arg ? arg : "<NONE>");
 		if (*activep && options->gss_kex_algorithms == NULL)

--- a/servconf.c
+++ b/servconf.c
@@ -1529,7 +1529,7 @@ process_server_config_line(ServerOptions *options, char *line,
 		if (!arg || *arg == '\0')
 			fatal("%.200s line %d: Missing argument.",
 			    filename, linenum);
-		if (!gss_kex_names_valid(arg))
+		if (!kex_gss_names_valid(arg))
 			fatal("%.200s line %d: Bad GSSAPI KexAlgorithms '%s'.",
 			    filename, linenum, arg ? arg : "<NONE>");
 		if (*activep && options->gss_kex_algorithms == NULL)

--- a/ssh.1
+++ b/ssh.1
@@ -579,6 +579,8 @@ flag),
 (supported message integrity codes),
 .Ar kex
 (key exchange algorithms),
+.Ar kex-gss
+(GSSAPI key exchange algorithms),
 .Ar key
 (key types),
 .Ar key-cert

--- a/ssh.c
+++ b/ssh.c
@@ -736,6 +736,8 @@ main(int ac, char **av)
 				cp = mac_alg_list('\n');
 			else if (strcmp(optarg, "kex") == 0)
 				cp = kex_alg_list('\n');
+			else if (strcmp(optarg, "kex-gss") == 0)
+				cp = kex_gss_alg_list('\n');
 			else if (strcmp(optarg, "key") == 0)
 				cp = sshkey_alg_list(0, 0, 0, '\n');
 			else if (strcmp(optarg, "key-cert") == 0)
@@ -748,7 +750,7 @@ main(int ac, char **av)
 				cp = xstrdup("2");
 			else if (strcmp(optarg, "help") == 0) {
 				cp = xstrdup(
-				    "cipher\ncipher-auth\nkex\nkey\n"
+				    "cipher\ncipher-auth\nkex\nkex-gss\nkey\n"
 				    "key-cert\nkey-plain\nmac\n"
 				    "protocol-version\nsig");
 			}


### PR DESCRIPTION
This is an addition to #2, which moves the gssapi kex algorithms away from the default list of kex algorithms so they do not interfere in other functions. This adds a new query option to ssh, listing only the GSSAPI kex algorithms.