### PR TITLE
Clean up if gss_indicate_mechs fails

### DIFF
--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -797,7 +797,9 @@ userauth_gssapi(struct ssh *ssh)
 	 * once. */
 
 	if (authctxt->gss_supported_mechs == NULL)
-		if (GSS_ERROR(gss_indicate_mechs(&min, &authctxt->gss_supported_mechs))) {
+		if (GSS_ERROR(gss_indicate_mechs(&min,
+		    &authctxt->gss_supported_mechs))) {
+			authctxt->gss_supported_mechs = NULL;
 			free(gss_host);
 			return 0;
 		}


### PR DESCRIPTION
If gss_indicate_mechs fails, then it might have modified
authctxt->gss_supported_mechs before failing.  Make sure to restore it
to its initial state in that case.