### PR TITLE
Enable SHA2-based GSSAPI key exchange methods by default as RFC 8732 …

### DIFF
--- a/ssh-gss.h
+++ b/ssh-gss.h
@@ -77,8 +77,12 @@
 #define KEX_GSS_C25519_SHA256_ID			"gss-curve25519-sha256-"
 
 #define        GSS_KEX_DEFAULT_KEX \
-	KEX_GSS_GEX_SHA1_ID "," \
-	KEX_GSS_GRP14_SHA1_ID
+	KEX_GSS_GRP14_SHA256_ID	"," \
+	KEX_GSS_GRP16_SHA512_ID	"," \
+	KEX_GSS_NISTP256_SHA256_ID "," \
+	KEX_GSS_C25519_SHA256_ID "," \
+	KEX_GSS_GRP14_SHA1_ID "," \
+	KEX_GSS_GEX_SHA1_ID
 
 typedef struct {
 	char *filename;

--- a/ssh_config.5
+++ b/ssh_config.5
@@ -825,8 +825,9 @@ gss-curve25519-sha256-
 .Ed
 .Pp
 The default is
-.Dq gss-gex-sha1-,gss-group14-sha1- .
-This option only applies to protocol version 2 connections using GSSAPI.
+.Dq gss-group14-sha256-,gss-group16-sha512-,gss-nistp256-sha256-,
+gss-curve25519-sha256-,gss-gex-sha1-,gss-group14-sha1- .
+This option only applies to connections using GSSAPI.
 .It Cm HashKnownHosts
 Indicates that
 .Xr ssh 1

--- a/sshd_config.5
+++ b/sshd_config.5
@@ -688,8 +688,9 @@ gss-curve25519-sha256-
 .Ed
 .Pp
 The default is
-.Dq gss-gex-sha1-,gss-group14-sha1- .
-This option only applies to protocol version 2 connections using GSSAPI.
+.Dq gss-group14-sha256-,gss-group16-sha512-,gss-nistp256-sha256-,
+gss-curve25519-sha256-,gss-gex-sha1-,gss-group14-sha1- .
+This option only applies to connections using GSSAPI.
 .It Cm HostbasedAcceptedKeyTypes
 Specifies the key types that will be accepted for hostbased authentication
 as a list of comma-separated patterns.


### PR DESCRIPTION
…was published