### PR TITLE
Reenable MONITOR_REQ_GSSCHECKMIC after gssapi-with-mic failures

### DIFF
--- a/monitor.c
+++ b/monitor.c
@@ -355,8 +355,15 @@ monitor_child_preauth(struct ssh *ssh, struct monitor *pmonitor)
 		if (ent->flags & (MON_AUTHDECIDE|MON_ALOG)) {
 			auth_log(ssh, authenticated, partial,
 			    auth_method, auth_submethod);
-			if (!partial && !authenticated)
+			if (!partial && !authenticated) {
+#ifdef GSSAPI
+				/* If gssapi-with-mic failed, MONITOR_REQ_GSSCHECKMIC is disabled.
+				 * We have to reenable it to try again for gssapi-keyex */
+				if (strcmp(auth_method, "gssapi-with-mic") == 0 && options.gss_keyex)
+					monitor_permit(mon_dispatch, MONITOR_REQ_GSSCHECKMIC, 1);
+#endif
 				authctxt->failures++;
+			}
 			if (authenticated || partial) {
 				auth2_update_session_info(authctxt,
 				    auth_method, auth_submethod);


### PR DESCRIPTION
Hopefully fixes #20

`MONITOR_REQ_GSSCHECKMIC` request type gets forbidden after `gssapi-with-mic` failures as it is intended to be processed only once.
In case when `gssapi-keyex` is processed after that, it causes the immediate failure. 

Looks like the best possible option is restoring the permission after the authorization is failed and `gssapi-keyex` is permitted. 